### PR TITLE
Rfc8179 part1

### DIFF
--- a/draft-rsalz-2026bis.md
+++ b/draft-rsalz-2026bis.md
@@ -134,7 +134,7 @@ ARPA
 Department of Defense.
 
 Blanket IPR Statement or Blanket Disclosure
-: See {{sec543}}.
+: See <<sec543 from 8179>>.
 
 Contribution
 : Any submission to the IETF intended by the Contributor for publication as
@@ -204,7 +204,7 @@ shall not have been withdrawn, cancelled, or disclaimed, nor held invalid by
 a court of competent jurisdiction in an unappealed or unappealable decision.
 
 General Disclosure:
-See {{general-disclosures}}.
+See <<general-disclosures from 8179>>.
 
 IETF
 : In the context of this document, the IETF includes all individuals who
@@ -1356,7 +1356,12 @@ subject of a variance: {{sec51}}, {{sec61}}, {{sec611}} (first paragraph),
 
 # Intellectual Property Rights {#sec10}
 
-## Background
+This section is not intended as legal advice. Readers are advised
+to consult their own legal advisors if they would like a legal
+interpretation of their rights or the rights of the IETF Trust
+{{?RFC8714}} in any Contributions they make.
+
+## Rights Contributors Provide to the IETF Trust
 
 In all matters of copyright and document procedures, the intent is to
 benefit the Internet community and the public at large, while respecting
@@ -1380,18 +1385,9 @@ necessary rights to the IETF.  In addition, Contributors must make
 representations to the IETF Trust and the IETF regarding their ability
 to grant these rights.
 
-{{?RFC8179}} deals with rights,
-including possible patent rights, in technologies developed or specified
-as part of the IETF Standards Process.  This document is not intended to
-address those issues.
+### Exposition of Why These Procedures Are the Way They Are
 
-## Exposition of Why These Procedures Are the Way They Are
-
-This memo does not retroactively obtain additional rights from
-Contributions that predate the date that the IETF Trust announces the
-adoption of these procedures.
-
-### Rights Granted in Contributions
+#### Rights Granted in Contributions
 
 The IETF Trust and the IETF must obtain the right to publish an IETF
 Contribution as an RFC or an Internet-Draft from the Contributors.
@@ -1415,7 +1411,7 @@ the rights that it is granted under this document.  In granting such other
 sublicenses, the IETF Trust will be guided and bound by documents such as
 {{RFC5377}}.
 
-### Rights to Use Contributions
+#### Rights to Use Contributions
 
 It is important that the IETF receive assurances from all Contributors
 that they have the authority to grant the IETF the rights that they
@@ -1431,7 +1427,7 @@ To this end, the IETF asks Contributors to give the assurances in
 extent of the Contributor's reasonable and personal knowledge as
 defined above.
 
-### Right to Produce Derivative Works
+#### Right to Produce Derivative Works
 
 The IETF needs to be able to evolve IETF Documents in response to experience
 gained in the deployment of the technologies described in such IETF
@@ -1496,7 +1492,7 @@ which the production of derivative works is excluded, the Contributor must
 include a special legend in the Contribution, as specified in the Legend
 Instructions, in order to notify IETF participants about this restriction.
 
-### Rights to Use Trademarks
+#### Rights to Use Trademarks {#use-trademarks}
 
 Contributors may wish to seek trademark or service mark protection on any
 terms that are coined or used in their Contributions.  The IETF makes no
@@ -1508,7 +1504,7 @@ and modify the IETF Contribution.  This license does not authorize the IETF
 or others to use any trademark or service mark in connection with any product
 or service offering.
 
-### Contributions Not Subject to Copyright {#no-copyright}
+#### Contributions Not Subject to Copyright {#no-copyright}
 
 Certain documents, including those produced by the U.S. government and those
 which are in the public domain, may not be protected by the same copyright
@@ -1525,7 +1521,7 @@ does not have the resources or wherewithal to make any independent
 investigation as to the actual proprietary status of any document submitted
 to it.
 
-### Copyright in RFCs
+#### Copyright in RFCs
 
 As noted above, Contributors to the IETF (or their employers) retain
 ownership of the copyright in their Contributions.  This includes
@@ -1545,7 +1541,9 @@ IETF, it actually reflects historical practice and has been observed for many
 years through the inclusion of an ISOC or IETF Trust copyright notice on all
 RFC documents since the publication of {{?RFC2026}}.
 
-### General Policy
+### Rights in Contributions
+
+#### General Policy
 
 By submission of a Contribution, each person actually submitting the
 Contribution and each named co-Contributor is deemed to have read and
@@ -1567,7 +1565,7 @@ such agreement by each Contributor, and each IETF participant expressly
 relies on the agreement of each Contributor to the terms and conditions
 set forth in this document.
 
-### Confidentiality Obligations
+#### Confidentiality Obligations
 
 No information or document that is subject to any requirement of
 confidentiality or any restriction on its dissemination may be submitted
@@ -1579,7 +1577,7 @@ generated automatically or otherwise, that states or implies that the
 Contribution is confidential or subject to any privilege, can be
 disregarded for all purposes, and will be of no force or effect.
 
-### Rights Granted by Contributors to the IETF Trust {#rights-granted}
+#### Rights Granted by Contributors to the IETF Trust {#rights-granted}
 
 To the extent that a Contribution or any portion thereof is protected by
 copyright or other rights of authorship, the Contributor and each named
@@ -1608,7 +1606,7 @@ thereof as permitted by this section, provided that when reproducing
 Contributions, trademark and service mark identifiers used in the
 Contribution, including TM and (R), will be preserved.
 
-### Sublicenses by the IETF Trust
+#### Sublicenses by the IETF Trust
 
 The IETF Trust will sublicense the rights granted to it under
 {{rights-granted}} to all IETF participants for use within the IETF
@@ -1623,14 +1621,14 @@ In addition, the IETF Trust may grant additional sublicenses of the licenses
 granted to it hereunder.  In doing so, the IETF Trust will comply with the
 guidance provided under {{!RFC5377}}.
 
-### No Patent License
+#### No Patent License
 
 The licenses granted in {{rights-granted}} shall not be deemed to grant any
 right under any patent, patent application, or other similar intellectual
-property right disclosed by the Contributor under {{RFC8179}} or
+property right disclosed by the Contributor under <<RFC8179>> or
 otherwise.
 
-### Representations and Warranties {#rep-and-warranty}
+#### Representations and Warranties {#rep-and-warranty}
 
 With respect to each Contribution, each Contributor represents that, to
 the best of his or her knowledge and ability:
@@ -1655,22 +1653,22 @@ principal place of business or residence.
 names used in the Contribution that are reasonably and personally known
 to the Contributor are clearly designated as such where reasonable.
 
-### No Duty to Publish
+#### No Duty to Publish
 
 The Contributor, and each named co-Contributor, acknowledges that the
 IETF has no duty to publish or otherwise use or disseminate any
 Contribution.  The IETF reserves the right to withdraw or cease using any
 Contribution that does not comply with the requirements of this section.
 
-### Trademarks
+#### Trademarks
 
 Contributors who claim trademark rights in terms used in their IETF
 Contributions are requested to state specifically what conditions apply
 to implementers of the technology relative to the use of such
 trademarks.  Such statements should be submitted in the same way as is
-done for other intellectual property claims.  (See {{RFC8179, Section 5}}.)
+done for other intellectual property claims.  (See <<RFC8179, Section 5>>.)
 
-### Copyright in RFCs {#rfc-copyrights}
+#### Copyright in RFCs {#rfc-copyrights}
 
 Subject to each Contributor's (or its sponsor's) ownership of its underlying
 Contributions as described in {{rep-and-warranty}} (which ownership is
@@ -1684,7 +1682,7 @@ publication, and acknowledges that a copyright notice acknowledging the IETF
 Trust's ownership of the copyright in such RFC will be included in the
 published RFC.
 
-### Contributors' Retention of Rights
+#### Contributors' Retention of Rights
 
 Although Contributors provide specific rights to the IETF, it is not intended
 that this should deprive them of their right to exploit their Contributions.
@@ -1695,7 +1693,7 @@ to the restriction that no Contributor has the right to represent any
 document as an RFC, or equivalent of an RFC, if it is not a full and complete
 copy or translation of the published RFC.
 
-##  Legends, Notices and Other Standardized Text in IETF Documents
+###  Legends, Notices and Other Standardized Text in IETF Documents
 
 The IETF requires that certain standardized text be reproduced verbatim
 in certain IETF Documents (including copies, derivative works, and
@@ -1766,7 +1764,7 @@ the "rfcindex.txt" file.
 
 - Draft 8: Incorporate RFC 7127.
 
-- Draft 8: Incorporate RFC 8179.
+- Draft 9: Incorporate RFC 8789.
 Updates (not obsoletes) RFC5378, RFC5657, and RFC7475.
 
 --- back

--- a/draft-rsalz-2026bis.md
+++ b/draft-rsalz-2026bis.md
@@ -32,7 +32,6 @@ venue:
 normative:
 
 informative:
-    RFC2026:
     US-ASCII:
       title: Coded Character Set -- 7-Bit American Standard Code for Information Interchange
       author:
@@ -122,41 +121,65 @@ The following terms are used throughout this document.
 For more details about the organizations related to the IETF, see
 {{!RFC9281, Section 3}}.
 
+Alternate Stream
+:  The IAB Document Stream, the IRTF Document Stream, and the Independent
+Submission Stream, each as defined in {{?RFC8729, Section 5.1}}, along with
+any future non-IETF streams that might be defined.
+
 Area Director
 : The manager of an IETF Area.
 
+ARPA
+: Advanced Research Projects Agency; an agency of the US
+Department of Defense.
+
+Blanket IPR Statement or Blanket Disclosure
+: See {{sec543}}.
+
 Contribution
 : Any submission to the IETF intended by the Contributor for publication as
-all or part of an Internet-Draft or RFC
-and any statement made within the context of
-an IETF activity.  Such statements include oral statements in IETF sessions
-as well as written and electronic communications, made at any time or place,
-that are addressed to:
+all or part of an Internet-Draft or RFC and any statement made within the
+context of an IETF activity, in each case that is intended to affect the IETF
+Standards Process or that is related to the activity of an Alternate Stream
+that has adopted this policy.
 
-- The IETF plenary session,
+Such statements include oral statements, as well as written and electronic
+communications, which are addressed to:
 
-- Any IETF working group or portion thereof,
+- Any IETF plenary session,
 
-- Any Birds of a Feather (BOF) session,
+- Any IETF Working Group (WG; see {{?BCP25}}) or portion thereof or
+any WG chair on behalf of the relevant WG,
+
+- Any IETF "birds of a feather" (BOF) session or portion thereof,
+
+- WG design teams (see {{BCP25}}) and other design teams that intend
+to deliver an output to IETF, or portions thereof,
 
 - The IESG, or any member thereof on behalf of the IESG,
 
 - The IAB, or any member thereof on behalf of the IAB,
 
-- Any IETF mailing list, including the IETF list itself, any working
-group or design team list, or any other list functioning under IETF
-auspices,
+- Any IETF mailing list, web site, chat room, or discussion board
+operated by or under the auspices of the IETF, including the
+IETF list itself,
 
 - The RFC Editor or the Internet-Drafts function.
 
-Statements made outside of an IETF session, mailing list, or other
-function, that are clearly not intended to be input to an IETF activity,
-group, or function are not IETF Contributions in the context of this
-document.
-
-ARPA
-: Advanced Research Projects Agency; an agency of the US
-Department of Defense.
+Statements made outside of an IETF session, mailing list, or other function,
+or that are clearly not intended to be input to an IETF activity, group, or
+function, are not Contributions in the context of this document.  And while
+the IETF's IPR rules apply in all cases, not all presentations represent a
+Contribution.  For example, many invited plenary, area-meeting, or research
+group presentations will cover useful background material, such as general
+discussions of existing Internet technology and products, and will not be a
+Contribution.  (Some such presentations can represent a Contribution as well,
+of course).  Throughout this document, the term "written Contribution" is
+used.  For purposes of this document, "written" means reduced to a written or
+visual form in any language and any media, permanent or temporary, including
+but not limited to traditional documents, email messages, discussion board
+postings, slide presentations, text messages, instant messages, and
+transcriptions of oral statements.
 
 Contributor
 : An individual submitting a Contribution.
@@ -169,6 +192,19 @@ author has in a work, such as the rights to copy, publish, distribute and
 create derivative works of the work.  An author often cedes these rights to
 his or her employer or other parties as a condition of employment or
 compensation.
+
+Covers or Covered
+: A valid claim of a patent or a patent application (including a provisional
+patent application) in any jurisdiction, or any other Intellectual Property
+Right, would necessarily be infringed by the exercise of a right (e.g.,
+making, using, selling, importing, distribution, copying, etc.) with respect
+to an Implementing Technology.  For purposes of this definition, "valid
+claim" means a claim of any unexpired patent or patent application which
+shall not have been withdrawn, cancelled, or disclaimed, nor held invalid by
+a court of competent jurisdiction in an unappealed or unappealable decision.
+
+General Disclosure:
+See {{general-disclosures}}.
 
 IETF
 : In the context of this document, the IETF includes all individuals who
@@ -184,27 +220,33 @@ of Working Groups related to a general topic such as routing. An
 Area is managed by one or more Area Directors.
 
 IETF Documents
-: RFCs and Internet-Drafts that are used in the IETF Standards Process as
-defined here.  This is identical to the "IETF stream" defined in {{?RFC4844}}.
+: RFCs and Internet-Drafts that are published as
+part of the IETF Standards Process.  These are also referred to as
+"IETF Stream Documents" as defined in {{RFC8729, Section 5.1.1}}.
 
 IETF Standards Process
-: The activities undertaken by the IETF in any of the settings described in
-1(a) above.
+: The activities undertaken by the IETF in any of the settings described
+in the above definition of Contribution.  The IETF Standards Process may
+include participation in activities and publication of documents that
+are not directed toward the development of IETF standards or
+specifications, such as the development and publication of Informational
+and Experimental documents (see {{sec4}}).
 
 IETF Trust
 : A trust established under the laws of the Commonwealth of Virginia, USA, in
 order to hold and administer intellectual property rights for the benefit of
 the IETF.
 
+Implementing Technology
+: A technology that implements an IETF specification or standard.
+
 Indirect Contributor
 : Any person who has materially or substantially contributed to a
 Contribution without being personally involved in its submission to the IETF.
 
 Internet-Draft
-: Temporary documents used in the IETF Standards Process.  Internet-Drafts
-are posted on the IETF web site by the IETF Secretariat.  As noted in
-{{sec22}}, Internet-Drafts have a nominal maximum lifetime of six months in
-the IETF Secretariat's public directory.
+: A document used in the IETF and RFC Editor
+processes, as described in {{sec2}}.
 
 Internet Engineering Steering Group (IESG)
 : A group comprised of the
@@ -215,6 +257,12 @@ standards approval board for the IETF.
 interoperable
 : For the purposes of this document, "interoperable"
 means to be able to interoperate over a data communications path.
+
+IPR or Intellectual Property Rights
+: Means a patent, utility model, or similar right that may Cover an
+Implementing Technology, whether such rights arise from a registration or
+renewal thereof, or an application therefore, in each case anywhere in the
+world.  See {{use-trademarks}} for a discussion of trademarks.
 
 Last-Call
 : A public comment period used to gauge the level of
@@ -228,23 +276,32 @@ standardized text in IETF Documents.  The text and instructions are posted
 from time to time at the
 [Trust Legal Provisions](https://trustee.ietf.org/documents/trust-legal-provisions/)
 
+Participating in an IETF discussion or activity
+: Making a Contribution, as described above, or in any other way acting in
+order to influence the outcome of a discussion relating to the IETF Standards
+Process.  Without limiting the generality of the foregoing, acting as a
+Working Group Chair or Area Director constitutes "Participating" in all
+activities of the relevant working group(s) he or she is responsible for in
+an area.  "Participant" and "IETF Participant" mean any individual
+Participating in an IETF discussion or activity.
+
 RFC
-: The publication series used by the IETF among others.  RFCs are published
-by the RFC Editor.  Although RFCs may be superseded in whole or in part
-by subsequent RFCs, the text of an RFC is not altered once published in
-RFC form.  (See {{sec21}}.)
+: The basic publication series for the IETF.
 
 Reasonably and personally known
 : Something an individual knows personally or, because of the job the
 individual holds, would reasonably be expected to know.  This wording is used
 to indicate that an organization cannot purposely keep an individual in the
-dark about certain information just to avoid the disclosure requirement.
+dark about patents or patent applications just to avoid the disclosure
+requirement.  But this requirement should not be interpreted as requiring the
+IETF Contributor or Participant (or his or her represented organization, if
+any) to perform a patent search to find applicable IPR.
 
 Working Group
 : A group chartered by the IESG and IAB to work on a
 specific specification, set of specifications or topic.
 
-# The Internet Standards Process
+# The Internet Standards Process {#std-process}
 
 In outline, the process of creating an Internet Standard is
 straightforward: a specification undergoes a period of development
@@ -1486,7 +1543,7 @@ not do so in the RFC format used by the IETF.  And while this principle
 (which is included in {{rfc-copyrights}} below) may appear to be new to the
 IETF, it actually reflects historical practice and has been observed for many
 years through the inclusion of an ISOC or IETF Trust copyright notice on all
-RFC documents since the publication of {{RFC2026}}.
+RFC documents since the publication of {{?RFC2026}}.
 
 ### General Policy
 


### PR DESCRIPTION
This is part 1 of the final merge of 8179. I will not post this as a new draft version, but am splitting it up into
more manageable piece.

This PR has the unified set of definitions (where duplicated, 8179 takes precedence over 5378, which in turn takes precedence over the previous 2026bis draft), and moves the RFC5378 down a section level. Part 2 will probably do all the rest of 8179.
